### PR TITLE
Add Docker Hub login to avoid unauthenticated pull rate limits

### DIFF
--- a/.github/workflows/website-build-push-test.yml
+++ b/.github/workflows/website-build-push-test.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Log in to ECR
         if: inputs.push
         uses: docker/login-action@v2


### PR DESCRIPTION
## Summary
- Adds a `docker/login-action` step to authenticate with Docker Hub before the build step
- Uses the org-level `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets (already defined and inherited)
- Prevents `429 Too Many Requests` errors when pulling base images (e.g. `node:14.21-alpine`) from Docker Hub during parallel CI builds

## Test plan
- [ ] Merge and re-run a previously rate-limited deploy to confirm the 429 error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)